### PR TITLE
Move hook to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm i tyin
 Create the hook:
 
 ```tsx
-import storeHook from "tyin/hook";
+import storeHook from "tyin";
 
 export const useActivePage = storeHook(1);
 ```
@@ -60,7 +60,7 @@ const Pagination = ({ maxPage }: PaginationProps) => {
 Real life applications are often complex, so let's add the `patch` function from the object plugin to handle partial updates:
 
 ```tsx
-import storeHook from "tyin/hook";
+import storeHook from "tyin";
 import extend from "tyin/extend";
 import objectAPI from "tyin/plugin-object";
 
@@ -91,7 +91,7 @@ In this example, we will add it, along with the persist plugin,
 and a custom setter called `complete`:
 
 ```tsx
-import storeHook from "tyin/hook";
+import storeHook from "tyin";
 import extend from "tyin/extend";
 import arrayAPI from "tyin/plugin-array";
 import persist from "tyin/plugin-persist";
@@ -141,7 +141,7 @@ After the store has been set up we can,
 pull the state when a component mounts by using the `usePull` hook. To push or delete, we can just call the functions directly on the `sync` API.
 
 ```tsx
-import storeHook from "tyin/hook";
+import storeHook from "tyin";
 import sync from "tyin/plugin-sync";
 import extend from "tyin/extend";
 import useHydrate from "tyin/plugin-sync/useHydrate";
@@ -202,18 +202,18 @@ fully featured state management solution in just a few bytes!
 
 Tyin doesn't come with a single entry point—that's intentional!
 
-It instead ships a couple of highly standalone modules,
+It instead ships standalone modules that are meant to extend each other,
 so that the user can import only the functionality that they need.
 
 ### 2. Genericism
 
 Tyin exposes generic APIs that aim to maximize ergonomics and minimize bundle size.
-Generic APIs facilitate code reuse, leading to synergies in consuming applications.
+Generic APIs facilitate code reuse which leads to synergies in consuming applications.
 
 For example: There is no `ObjectAPI.setKey(key, value)` function,
 because `ObjectAPI.patch({ [key]: value })` covers that need
-and a lot of other needs, simply by providing a generic API.
-This API is powerful enough to receive aggressive reuse in the consuming app; leading to an even smaller bundle size overall.
+and many others, simply by being more generic.
+This API is powerful enough to receive aggressive reuse in the consuming app; leading to an even smaller overall bundle size.
 
 ### 3. Composability
 
@@ -244,7 +244,7 @@ store: 245 bytes, 212 gzipped
 ```
 
 So, that means if you import everything; Tyin will add ~900 bytes to your bundle size,
-and the most minimal implementation (just `tyin/hook`) would only add ~350 bytes.
+and the most minimal implementation (importing just `tyin`) would only add ~350 bytes.
 
 But this all depends on your bundler and configuration. In real-life scenarios it is often less. For dott.bio—using the `export-object.js` variant measured above—Tyin adds 550 bytes (according to `next/bundle-analyzer`).
 

--- a/src/__test__/_export-all.ts
+++ b/src/__test__/_export-all.ts
@@ -1,5 +1,5 @@
 // This is here to measure the bundle size of the library:
-export * from "../hook";
+export * from "../index";
 export * from "../store";
 export * from "../extend";
 export * from "../plugin-array";

--- a/src/__test__/_export-common.ts
+++ b/src/__test__/_export-common.ts
@@ -1,5 +1,5 @@
 // This is here to measure the bundle size of the library:
-export * from "../hook";
+export * from "../index";
 export * from "../extend";
 export * from "../plugin-object";
 export * from "../plugin-persist";

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ const bindHook = <T extends AnyState>(
  * @template T The type of the state.
  * @example
  * ```ts
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import extend from "tyin/extend";
  * import objectAPI from "tyin/plugin-object";
  *

--- a/src/plugin-array.ts
+++ b/src/plugin-array.ts
@@ -34,7 +34,7 @@ export type ArrayAPIPlugin<T extends any[] | null> = Plugin<
  * @template T The type of the state, must be an array type.
  * @example
  * ```ts
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import extend from "tyin/extend";
  * import arrayAPI from "tyin/plugin-array";
  *

--- a/src/plugin-object.ts
+++ b/src/plugin-object.ts
@@ -62,7 +62,7 @@ const mergeLeft = <T extends ObjectLike | null, U = Partial<T>>(
  * @template T The type of the state, must be an object type.
  * @example
  * ```ts
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import extend from "tyin/extend";
  * import objectAPI from "tyin/plugin-object";
  *

--- a/src/plugin-persist.ts
+++ b/src/plugin-persist.ts
@@ -42,7 +42,7 @@ const localStorage = typeof window !== "undefined" ? window.localStorage : null;
  * @template T The type of the state.
  * @example
  * ```ts
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import extend from "tyin/extend";
  * import persist from "tyin/plugin-persist";
  *

--- a/src/plugin-reducer.ts
+++ b/src/plugin-reducer.ts
@@ -52,7 +52,7 @@ export type Reducer<T extends AnyState, A> = (state: T, action: A) => T;
  * @template A The type of the actions.
  * @example
  * ```ts
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import extend from "tyin/extend";
  * import reducerAPI, { Action, Payload } from "tyin/plugin-reducer";
  *

--- a/src/plugin-sync.ts
+++ b/src/plugin-sync.ts
@@ -141,7 +141,7 @@ export type SyncPlugin<T extends AnyState, R extends {}> = Plugin<
  *
  * @example
  * ```ts
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import sync from "tyin/plugin-sync";
  * import extend from "tyin/extend";
  * import { Note } from "@/types";

--- a/src/util-debounce.ts
+++ b/src/util-debounce.ts
@@ -5,7 +5,7 @@
  * @param callback A function to call.
  * @example
  * ```ts
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import debounce from "tyin/util-debounce";
  *
  * const useExample = storeHook({ a: 1, b: 2 });

--- a/src/util-deep-merge.ts
+++ b/src/util-deep-merge.ts
@@ -29,7 +29,7 @@ export type DeepMerged<T extends PlainObject, P extends PlainObject> = {
  * @param patch The patch object to merge from.
  * @example
  * ```
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import extend from "tyin/extend";
  * import objectAPI from "tyin/object";
  * import deepMerge from "tyin/util-deep-merge";

--- a/src/util-throttle.ts
+++ b/src/util-throttle.ts
@@ -5,7 +5,7 @@
  * @param callback A function to call.
  * @example
  * ```ts
- * import storeHook from "tyin/hook";
+ * import storeHook from "tyin";
  * import extend from "tyin/extend";
  * import throttle from "tyin/util-throttle";
  *


### PR DESCRIPTION
This should make the DX better for people (like me) who never read the official documentation, and prefer to just explore the library organically.

This is obviously a BREAKING CHANGE.